### PR TITLE
Improve style toolbar and Korean UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,11 @@ interface ReportComponent {
   text?: string;
   tableData?: string[][];
   style?: {
-    fontSize?: string;
+    fontSize?: number;
     textAlign?: 'left' | 'center' | 'right';
     fontWeight?: 'normal' | 'bold';
+    fontStyle?: 'normal' | 'italic';
+    textDecoration?: 'none' | 'underline';
     color?: string;
     backgroundColor?: string;
   };

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useDrop } from 'react-dnd';
 import { ReportComponent } from '../App';
 import { Rnd } from 'react-rnd';
+import TopToolbar from './TopToolbar';
 
 interface Props {
     components: ReportComponent[];
@@ -182,8 +183,16 @@ function Canvas({ components, setComponents }: Props) {
         );
     };
 
+    const selectedComponent = components.find((c) => c.id === selectedId);
+
     return (
         <div ref={divRef} style={{ flex: 1, background: 'white', position: 'relative' }}>
+            <TopToolbar
+                component={selectedComponent}
+                updateStyle={(style) => {
+                    if (selectedId) updateStyle(selectedId, style);
+                }}
+            />
             {components.map((comp) => (
                 <Rnd
                     key={comp.id}
@@ -367,6 +376,7 @@ function Canvas({ components, setComponents }: Props) {
                                         width: 20,
                                         height: 20,
                                         cursor: 'pointer',
+                                        zIndex: 20,
                                     }}
                                 >
                                     ×
@@ -377,73 +387,6 @@ function Canvas({ components, setComponents }: Props) {
                 </Rnd>
             ))}
 
-            {selectedId && (
-                <div className="fixed right-4 top-4 bg-white p-4 shadow rounded space-y-2">
-                    <div>
-                        <label className="mr-2">Font Size</label>
-                        <input
-                            type="number"
-                            className="border px-1"
-                            value={components.find((c) => c.id === selectedId)?.style?.fontSize || ''}
-                            onChange={(e) => updateStyle(selectedId, { fontSize: Number(e.target.value) })}
-                        />
-                    </div>
-                    <div>
-                        <label className="mr-2">Font Color</label>
-                        <input
-                            type="color"
-                            value={components.find((c) => c.id === selectedId)?.style?.color || '#000000'}
-                            onChange={(e) => updateStyle(selectedId, { color: e.target.value })}
-                        />
-                    </div>
-                    <div>
-                        <label className="mr-2">Background</label>
-                        <input
-                            type="color"
-                            value={components.find((c) => c.id === selectedId)?.style?.backgroundColor || '#ffffff'}
-                            onChange={(e) => updateStyle(selectedId, { backgroundColor: e.target.value })}
-                        />
-                    </div>
-                    <div>
-                        <label className="mr-2">Align</label>
-                        <select
-                            className="border"
-                            value={components.find((c) => c.id === selectedId)?.style?.textAlign || 'left'}
-                            onChange={(e) => updateStyle(selectedId, { textAlign: e.target.value as any })}
-                        >
-                            <option value="left">Left</option>
-                            <option value="center">Center</option>
-                            <option value="right">Right</option>
-                        </select>
-                    </div>
-                    <div className="space-x-2">
-                        <label>
-                            <input
-                                type="checkbox"
-                                checked={components.find((c) => c.id === selectedId)?.style?.fontWeight === 'bold'}
-                                onChange={(e) => updateStyle(selectedId, { fontWeight: e.target.checked ? 'bold' : 'normal' })}
-                            />
-                            Bold
-                        </label>
-                        <label>
-                            <input
-                                type="checkbox"
-                                checked={components.find((c) => c.id === selectedId)?.style?.fontStyle === 'italic'}
-                                onChange={(e) => updateStyle(selectedId, { fontStyle: e.target.checked ? 'italic' : 'normal' })}
-                            />
-                            Italic
-                        </label>
-                        <label>
-                            <input
-                                type="checkbox"
-                                checked={components.find((c) => c.id === selectedId)?.style?.textDecoration === 'underline'}
-                                onChange={(e) => updateStyle(selectedId, { textDecoration: e.target.checked ? 'underline' : 'none' })}
-                            />
-                            Underline
-                        </label>
-                    </div>
-                </div>
-            )}
         </div>
     );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import DraggableComponent from './DraggableComponent';
 
 const COMPONENTS: { type: 'label' | 'table' | 'image'; name: string }[] = [
-    { type: 'label', name: 'Label' },
-    { type: 'table', name: 'Table' },
-    { type: 'image', name: 'Image' },
+    { type: 'label', name: '라벨' },
+    { type: 'table', name: '테이블' },
+    { type: 'image', name: '이미지' },
 ];
 
 function Sidebar() {
     return (
         <div style={{ width: 200, padding: 10, background: '#f4f4f4' }}>
-            <h3>Components</h3>
+            <h3>컴포넌트</h3>
             {COMPONENTS.map((comp) => (
                 <DraggableComponent key={comp.type} type={comp.type} name={comp.name} />
             ))}

--- a/src/components/TopToolbar.tsx
+++ b/src/components/TopToolbar.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { ReportComponent } from '../App';
+
+interface Props {
+  component?: ReportComponent;
+  updateStyle: (style: Partial<ReportComponent['style']>) => void;
+}
+
+function TopToolbar({ component, updateStyle }: Props) {
+  if (!component) return null;
+  const style = component.style || {};
+  return (
+    <div className="fixed top-0 left-0 right-0 bg-white shadow p-2 flex space-x-2 z-50">
+      <div>
+        <label className="mr-1">폰트 크기</label>
+        <input
+          type="number"
+          className="border px-1 w-20"
+          value={style.fontSize ?? ''}
+          onChange={(e) => updateStyle({ fontSize: Number(e.target.value) })}
+        />
+      </div>
+      <div>
+        <label className="mr-1">글자 색상</label>
+        <input
+          type="color"
+          value={style.color || '#000000'}
+          onChange={(e) => updateStyle({ color: e.target.value })}
+        />
+      </div>
+      <div>
+        <label className="mr-1">배경색</label>
+        <input
+          type="color"
+          value={style.backgroundColor || '#ffffff'}
+          onChange={(e) => updateStyle({ backgroundColor: e.target.value })}
+        />
+      </div>
+      <div>
+        <label className="mr-1">정렬</label>
+        <select
+          className="border"
+          value={style.textAlign || 'left'}
+          onChange={(e) => updateStyle({ textAlign: e.target.value as any })}
+        >
+          <option value="left">왼쪽</option>
+          <option value="center">가운데</option>
+          <option value="right">오른쪽</option>
+        </select>
+      </div>
+      <div className="flex items-center space-x-2">
+        <label>
+          <input
+            type="checkbox"
+            checked={style.fontWeight === 'bold'}
+            onChange={(e) => updateStyle({ fontWeight: e.target.checked ? 'bold' : 'normal' })}
+          />
+          <span className="ml-1">굵게</span>
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={style.fontStyle === 'italic'}
+            onChange={(e) => updateStyle({ fontStyle: e.target.checked ? 'italic' : 'normal' })}
+          />
+          <span className="ml-1">기울임</span>
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={style.textDecoration === 'underline'}
+            onChange={(e) => updateStyle({ textDecoration: e.target.checked ? 'underline' : 'none' })}
+          />
+          <span className="ml-1">밑줄</span>
+        </label>
+      </div>
+    </div>
+  );
+}
+
+export default TopToolbar;


### PR DESCRIPTION
## Summary
- update ReportComponent style fields in README
- show Korean labels in sidebar
- add fixed TopToolbar for style editing
- remove old property panel and fix delete button overlay

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68637be955f8832cabcf763cfedf939b