### PR TITLE
Add basic page and cell merge support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ export interface ReportComponent {
   type: 'label' | 'table' | 'image';
   x: number;
   y: number;
+  /** Page index that this component belongs to */
+  page: number;
   width?: number;
   height?: number;
   text?: string;
@@ -53,17 +55,24 @@ function App() {
     canRedo,
   } = useUndo<ReportComponent[]>([]);
   const [preview, setPreview] = React.useState(false);
+  const [pageCount, setPageCount] = React.useState(1);
 
   return (
     <DndProvider backend={HTML5Backend}>
       {preview ? (
-        <Preview components={components} onClose={() => setPreview(false)} />
+        <Preview
+          components={components}
+          pageCount={pageCount}
+          onClose={() => setPreview(false)}
+        />
       ) : (
         <div style={{ display: 'flex', height: '100vh', position: 'relative' }}>
           <Sidebar />
           <Canvas
             components={components}
             setComponents={setComponents}
+            pageCount={pageCount}
+            setPageCount={setPageCount}
             undo={undo}
             redo={redo}
             canUndo={canUndo}

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -5,10 +5,11 @@ import { ReportComponent } from '../App';
 
 interface Props {
   components: ReportComponent[];
+  pageCount: number;
   onClose: () => void;
 }
 
-function Preview({ components, onClose }: Props) {
+function Preview({ components, pageCount, onClose }: Props) {
   const ref = useRef<HTMLDivElement>(null);
 
   const exportPDF = async () => {
@@ -28,8 +29,21 @@ function Preview({ components, onClose }: Props) {
         <button onClick={onClose}>닫기</button>
         <button onClick={exportPDF}>PDF 저장</button>
       </div>
-      <div ref={ref} style={{ position: 'relative', background: 'white', minHeight: '90vh' }}>
-        {components.map((comp) => {
+      <div ref={ref} style={{ position: 'relative', background: 'white' }}>
+        {Array.from({ length: pageCount }).map((_, pageIndex) => (
+          <div
+            key={pageIndex}
+            style={{
+              width: 794,
+              height: 1123,
+              margin: '0 auto 20px',
+              position: 'relative',
+              border: '1px solid #ccc',
+            }}
+          >
+            {components
+              .filter((c) => c.page === pageIndex)
+              .map((comp) => {
           const style: React.CSSProperties = {
             position: 'absolute',
             left: comp.x,
@@ -52,14 +66,14 @@ function Preview({ components, onClose }: Props) {
                     <tr key={i}>
                       {row.map((cell, j) => (
                         comp.cellSpans?.[i]?.[j]?.colspan === 0 || comp.cellSpans?.[i]?.[j]?.rowspan === 0 ? null : (
-                        <td
-                          key={j}
-                          rowSpan={comp.cellSpans?.[i]?.[j]?.rowspan || 1}
-                          colSpan={comp.cellSpans?.[i]?.[j]?.colspan || 1}
-                          style={{ border: '1px solid #000', padding: 4 }}
-                        >
-                          {cell}
-                        </td>
+                          <td
+                            key={j}
+                            rowSpan={comp.cellSpans?.[i]?.[j]?.rowspan || 1}
+                            colSpan={comp.cellSpans?.[i]?.[j]?.colspan || 1}
+                            style={{ border: '1px solid #000', padding: 4 }}
+                          >
+                            {cell}
+                          </td>
                         )
                       ))}
                     </tr>
@@ -69,7 +83,9 @@ function Preview({ components, onClose }: Props) {
             );
           }
           return null;
-        })}
+              })}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/components/TopToolbar.tsx
+++ b/src/components/TopToolbar.tsx
@@ -19,14 +19,14 @@ function TopToolbar({ component, updateStyle, undo, redo, canUndo, canRedo }: Pr
         disabled={!canUndo}
         className="border rounded px-2 py-1 text-sm disabled:opacity-50"
       >
-        Undo
+        되돌리기
       </button>
       <button
         onClick={redo}
         disabled={!canRedo}
         className="border rounded px-2 py-1 text-sm disabled:opacity-50"
       >
-        Redo
+        다시하기
       </button>
       {component && (
         <>


### PR DESCRIPTION
## Summary
- support multiple A4 sized pages on the canvas
- localize undo/redo buttons
- allow selecting cells to merge/unmerge
- update preview for pages

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_686385eff1d0832c8e7e1781363ae134